### PR TITLE
Add test for Event titles in search results

### DIFF
--- a/app/models/preservation/event.rb
+++ b/app/models/preservation/event.rb
@@ -16,14 +16,31 @@ module Preservation
       EventIndexer
     end
 
+    # Comprehensive list of all PREMIS event types.
     def self.premis_event_types
-      @premis_event_types ||= begin
-        {}.tap do |premis_event_types|
-          [:cap, :com, :cre, :dea, :dec, :del, :der, :dig, :fix, :ing, :mes,
-            :mig, :nor, :rep, :val, :vir].each do |type|
-            premis_event_types[type] = ::RDF::Vocab::PremisEventType.send(type)
-          end
-        end
+      @premis_event_types = [
+        PremisEventType.new('cap', 'PREMIS Capture'),
+        PremisEventType.new('com', 'PREMIS Compression'),
+        PremisEventType.new('cre', 'PREMIS Creation'),
+        PremisEventType.new('dea', 'PREMIS Deaccession'),
+        PremisEventType.new('dec', 'PREMIS Decryption'),
+        PremisEventType.new('del', 'PREMIS Deletion'),
+        PremisEventType.new('dig', 'PREMIS Digital Signature Validation'),
+        PremisEventType.new('fix', 'PREMIS Fixity Check'),
+        PremisEventType.new('ing', 'PREMIS Ingestion'),
+        PremisEventType.new('mes', 'PREMIS Message Digest Calculation'),
+        PremisEventType.new('mig', 'PREMIS Migration'),
+        PremisEventType.new('nor', 'PREMIS Normalization'),
+        PremisEventType.new('rep', 'PREMIS Replication'),
+        PremisEventType.new('val', 'PREMIS Validation'),
+        PremisEventType.new('vir', 'PREMIS Virus Check')
+      ]
+    end
+
+    # Fetch a PREMIS event type given it's abbreviation, label, or URI.
+    def self.premis_event_type(abbr_or_label_or_uri)
+      premis_event_types.each do |premis_event_type|
+        return premis_event_type if [premis_event_type.abbr, premis_event_type.label, premis_event_type.uri].include?(abbr_or_label_or_uri)
       end
     end
   end

--- a/app/models/preservation/premis_event_type.rb
+++ b/app/models/preservation/premis_event_type.rb
@@ -1,0 +1,14 @@
+module Preservation
+  class PremisEventType
+    attr_reader :abbr, :label
+
+    def initialize(abbr, label='')
+      @abbr = abbr
+      @label = label
+    end
+
+    def uri
+      ::RDF::Vocab::PremisEventType.send(abbr)
+    end
+  end
+end

--- a/app/presenters/preservation/event_presenter.rb
+++ b/app/presenters/preservation/event_presenter.rb
@@ -1,23 +1,7 @@
 module Preservation
   class EventPresenter < Blacklight::IndexPresenter
     def label(field, opts = {})
-      EventPresenter.premis_event_type_label(document.first(field))
-    end
-
-    def self.premis_event_type_label(premis_event_type_uri)
-      shortened_field_val = begin
-        URI(premis_event_type_uri).path.split('/').last
-      rescue ArgumentError
-        nil
-      end
-      # TODO: complete the list of premis event types: http://id.loc.gov/vocabulary/preservation/eventType.html
-      labels = {
-        'cap' => 'PREMIS Capture',
-        'fix' => 'PREMIS Fixity Check',
-        'ing' => 'PREMIS Ingestion',
-        'val' => 'PREMIS Validation'
-      }
-      labels[shortened_field_val] || 'unknown premis event type'
+      Event.premis_event_type(document.first(field)).label
     end
   end
 end

--- a/spec/factories/preservation/event.rb
+++ b/spec/factories/preservation/event.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :event, class: Preservation::Event do
-    premis_event_type { [Preservation::Event.premis_event_types.values.sample] }
+    premis_event_type { [Preservation::Event.premis_event_types.sample.uri] }
     premis_event_date_time { [DateTime.now - rand(30000).hours] }
     sequence(:premis_agent) { |n| [::RDF::URI.new("mailto:premis_agent_#{n}@hydradam.org")] }
   end

--- a/spec/features/preservation/search_events_spec.rb
+++ b/spec/features/preservation/search_events_spec.rb
@@ -10,10 +10,14 @@ describe 'Preservation Events search page' do
       expect(page).to have_css('li.document', count: 10)
     end
 
-    xit 'displays the PREMIS type for the title' do
+    it 'displays the PREMIS event type label for the title' do
+      # Make a regex that checks for any PREMIS event type label.
+      regex = /(#{Preservation::Event.premis_event_types.map(&:label).join('|')})/
+      expect(page).to have_css('h4.index_title a', text: regex)
     end
 
     it 'displays the PREMIS agent' do
+      # TODO: avoid using hardcoded dynamic solr suffix here
       expect(page).to have_css('dt.blacklight-premis_agent_ssim', count: 10)
     end
 


### PR DESCRIPTION
* Refactors PREMIS event types into object w/ uri, label, and abbreviation.