### PR TITLE
Adds rb-readline to the bundle

### DIFF
--- a/preservation.gemspec
+++ b/preservation.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-rails'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'launchy'
+  s.add_development_dependency 'rb-readline'
 end


### PR DESCRIPTION
Fixes error where byebug requires readline. Shows up when ruby is installed
without readline support on OSX.