### PR TITLE
Refactors PremisEventType model

### DIFF
--- a/app/models/preservation/event.rb
+++ b/app/models/preservation/event.rb
@@ -8,7 +8,7 @@ module Preservation
     property :premis_agent, predicate: ::RDF::Vocab::PREMIS.hasAgent
     property :premis_event_date_time, predicate: ::RDF::Vocab::PREMIS.hasEventDateTime
     property :premis_event_outcome, predicate: ::RDF::Vocab::PREMIS.hasEventOutcome
-    property :premis_event_detail, predicate: ::RDF::Vocab::PREMIS.hasEventDetail   
+    property :premis_event_detail, predicate: ::RDF::Vocab::PREMIS.hasEventDetail
 
     def user_from_db
       @user_from_db ||= User.where(email: premis_agent)
@@ -16,34 +16,6 @@ module Preservation
 
     def self.indexer
       EventIndexer
-    end
-
-    # Comprehensive list of all PREMIS event types.
-    def self.premis_event_types
-      @premis_event_types = [
-        PremisEventType.new('cap', 'PREMIS Capture'),
-        PremisEventType.new('com', 'PREMIS Compression'),
-        PremisEventType.new('cre', 'PREMIS Creation'),
-        PremisEventType.new('dea', 'PREMIS Deaccession'),
-        PremisEventType.new('dec', 'PREMIS Decryption'),
-        PremisEventType.new('del', 'PREMIS Deletion'),
-        PremisEventType.new('dig', 'PREMIS Digital Signature Validation'),
-        PremisEventType.new('fix', 'PREMIS Fixity Check'),
-        PremisEventType.new('ing', 'PREMIS Ingestion'),
-        PremisEventType.new('mes', 'PREMIS Message Digest Calculation'),
-        PremisEventType.new('mig', 'PREMIS Migration'),
-        PremisEventType.new('nor', 'PREMIS Normalization'),
-        PremisEventType.new('rep', 'PREMIS Replication'),
-        PremisEventType.new('val', 'PREMIS Validation'),
-        PremisEventType.new('vir', 'PREMIS Virus Check')
-      ]
-    end
-
-    # Return a PremisEventType given it's abbreviation, label, or URI.
-    def self.premis_event_type(abbr_or_label_or_uri)
-      premis_event_types.select do |premis_event_type|
-        [premis_event_type.abbr.to_sym, premis_event_type.abbr, premis_event_type.label, premis_event_type.uri].include?(abbr_or_label_or_uri)
-      end.first
     end
   end
 end

--- a/app/models/preservation/premis_event_type.rb
+++ b/app/models/preservation/premis_event_type.rb
@@ -10,5 +10,26 @@ module Preservation
     def uri
       ::RDF::Vocab::PremisEventType.send(abbr)
     end
+
+    # Returns an array of instances of all known PREMIS event types
+    def self.all
+      @all ||= [
+        new('cap', 'PREMIS Capture'),
+        new('com', 'PREMIS Compression'),
+        new('cre', 'PREMIS Creation'),
+        new('dea', 'PREMIS Deaccession'),
+        new('dec', 'PREMIS Decryption'),
+        new('del', 'PREMIS Deletion'),
+        new('dig', 'PREMIS Digital Signature Validation'),
+        new('fix', 'PREMIS Fixity Check'),
+        new('ing', 'PREMIS Ingestion'),
+        new('mes', 'PREMIS Message Digest Calculation'),
+        new('mig', 'PREMIS Migration'),
+        new('nor', 'PREMIS Normalization'),
+        new('rep', 'PREMIS Replication'),
+        new('val', 'PREMIS Validation'),
+        new('vir', 'PREMIS Virus Check')
+      ]
+    end
   end
 end

--- a/app/presenters/preservation/event_index_presenter.rb
+++ b/app/presenters/preservation/event_index_presenter.rb
@@ -1,7 +1,10 @@
 module Preservation
   class EventIndexPresenter < Blacklight::IndexPresenter
+    # Returns the value of PremisEventType#label for the PremisEventType instance
+    # whose #abbr value matches that which is in the solr document.
     def label(field, opts = {})
-      Event.premis_event_type(document.first(field)).label
+      premis_event_type = PremisEventType.all.find { |premis_event_type| premis_event_type.abbr == document.first(field) }
+      premis_event_type.label
     end
   end
 end

--- a/app/presenters/preservation/event_show_presenter.rb
+++ b/app/presenters/preservation/event_show_presenter.rb
@@ -2,7 +2,8 @@ module Preservation
   class EventShowPresenter < Blacklight::ShowPresenter
     def heading
       premis_event_type_abbr = document[Solrizer.solr_name(:premis_event_type, :symbol)].first
-      Preservation::Event.premis_event_type(premis_event_type_abbr).label
+      premis_event_type = Preservation::PremisEventType.all.find { |premis_event_type| premis_event_type.abbr == premis_event_type_abbr }
+      premis_event_type.label
     end
   end
 end

--- a/app/search_builders/preservation/events_search_builder.rb
+++ b/app/search_builders/preservation/events_search_builder.rb
@@ -67,7 +67,7 @@ module Preservation
     def premis_event_type_filter
       @premis_event_type_filter ||= begin
         if blacklight_params['premis_event_type']
-          valid_premis_abbrs = blacklight_params['premis_event_type'] & Preservation::Event.premis_event_types.map(&:abbr)
+          valid_premis_abbrs = blacklight_params['premis_event_type'] & Preservation::PremisEventType.all.map(&:abbr)
           "(#{valid_premis_abbrs.map { |abbr| "premis_event_type_ssim:#{abbr}"}.join(" OR ")})"
         end
       end

--- a/app/views/preservation/events/filter_search/_premis_event_type.html.erb
+++ b/app/views/preservation/events/filter_search/_premis_event_type.html.erb
@@ -1,6 +1,6 @@
 <h2>PREMIS Event Type</h2>
 <form id="premis_event_type_filter" action="<%= preservation.events_url %>">
-  <% Preservation::Event.premis_event_types.each do |premis_event_type| %>
+  <% Preservation::PremisEventType.all.each do |premis_event_type| %>
     <input type="checkbox" id="premis_event_type_<%= premis_event_type.abbr %>" name="premis_event_type[]" value="<%= premis_event_type.abbr %>" <%= Array(request.params['premis_event_type']).include?(premis_event_type.abbr) ? 'checked="checked"' : '' %>/>
     <label for="premis_event_type_<%= premis_event_type.abbr %>"><%= premis_event_type.label.sub(/^PREMIS/ , '') %></label>
   <% end %>

--- a/lib/preservation/event_logger.rb
+++ b/lib/preservation/event_logger.rb
@@ -4,7 +4,7 @@ module Preservation
   class EventLogger
     def self.log_preservation_event(opts={})
       Preservation::Event.new.tap do |pe|
-        pe.premis_event_type += [Preservation::Event.premis_event_types[opts[:premis_event_type].to_sym]]
+        pe.premis_event_type += [ Preservation::PremisEventType.all.select { |premis_event_type| premis_event_type.abbr == opts[:premis_event_type].to_sym } ]
         pe.premis_event_related_object = opts[:file_set]
         # Assume opts[:premis_agent] is an email address, and make a 'mailto:' RDF::URI out of it.
         pe.premis_agent += [::RDF::URI.new("mailto:#{opts[:premis_agent]}")]

--- a/spec/factories/preservation/event.rb
+++ b/spec/factories/preservation/event.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
       premis_agent_email false
     end
 
-    premis_event_type { [Preservation::Event.premis_event_types.sample.uri] }
+    premis_event_type { [Preservation::PremisEventType.all.sample.uri] }
     premis_event_date_time { [DateTime.now - rand(30000).hours] }
     premis_event_related_object { create(:file_set) }
     sequence(:premis_agent) { |n| [::RDF::URI.new("mailto:premis_agent_#{n}@hydradam.org")] }

--- a/spec/features/preservation/search_events_spec.rb
+++ b/spec/features/preservation/search_events_spec.rb
@@ -18,7 +18,7 @@ describe 'Preservation Events search results' do
 
     it 'displays the PREMIS event type label for the title' do
       # Make a regex that checks for any PREMIS event type label.
-      regex = /(#{Preservation::Event.premis_event_types.map(&:label).join('|')})/
+      regex = /(#{Preservation::PremisEventType.all.map(&:label).join('|')})/
       expect(page).to have_css('h4.index_title a', text: regex)
     end
 
@@ -83,7 +83,7 @@ describe 'Preservation Events search results' do
   end
 
   context 'filtered by PREMIS event type' do
-    let(:all_premis_event_types) { Preservation::Event.premis_event_types }
+    let(:all_premis_event_types) { Preservation::PremisEventType.all }
     let(:selected_premis_event_types) { all_premis_event_types.sample(4) }
 
     before do
@@ -119,7 +119,11 @@ describe 'Preservation Events search results' do
       # For each of the manually filtered records, expect it to be found among
       # the filtered search results.
       records_with_selected_premis_event_types.each do |record|
-        expect(page).to have_selector('h4.index_title a', text: Preservation::Event.premis_event_type(record.premis_event_type.first.id).label)
+        expected_text = begin
+          premis_event_type = Preservation::PremisEventType.all.find { |premis_event_type| premis_event_type.uri == record.premis_event_type.first.id }
+          premis_event_type.label
+        end
+        expect(page).to have_selector('h4.index_title a', text: expected_text)
       end
 
       # And ensure that none of the non-selected PREMIS event types show up

--- a/spec/features/preservation/show_event_spec.rb
+++ b/spec/features/preservation/show_event_spec.rb
@@ -8,8 +8,8 @@ describe 'Preservation Events details page' do
     before { visit "preservation/events/#{preservation_event.id}" }
 
     it 'displays the PREMIS event type' do
-      premis_event_type_label = Preservation::Event.premis_event_type(preservation_event.premis_event_type.first.to_uri.to_s).label
-      expect(page).to have_text(premis_event_type_label)
+      premis_event_type = Preservation::PremisEventType.all.find { |premis_event_type| premis_event_type.uri == preservation_event.premis_event_type.first.to_uri.to_s }
+      expect(page).to have_text(premis_event_type.label)
     end
 
     it 'displays the PREMIS agent' do

--- a/spec/models/preservation/event_spec.rb
+++ b/spec/models/preservation/event_spec.rb
@@ -4,4 +4,11 @@ describe Preservation::Event do
   it 'has a factory' do
     expect(FactoryGirl.create(:event)).to be_a Preservation::Event
   end
+
+  describe '#premis_event_type_label' do
+    let(:premis_event_type) { Preservation::Event.premis_event_types.sample }
+    it 'returns the label of the premis event type' do
+
+    end
+  end
 end

--- a/spec/models/preservation/premis_event_type_spec.rb
+++ b/spec/models/preservation/premis_event_type_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Preservation::PremisEventType do
+  let(:premis_event_type) { Preservation::PremisEventType.new('cap') }
+  let(:premis_event_type_uri_namespace) { 'http://id.loc.gov/vocabulary/preservation/eventType/' }
+
+  describe '#uri' do
+    it 'returns an RDF::Vocabulary::Term' do
+      expect(premis_event_type.uri).to be_a ::RDF::Vocabulary::Term
+    end
+
+    it 'returns a URI under the PREMIS Event Type namespace when converted to a string' do
+      expect(premis_event_type.uri.to_s).to match /#{premis_event_type_uri_namespace}/
+    end
+  end
+
+  describe '.all' do
+    it 'returns an array of PremisEventType instances' do
+      Preservation::PremisEventType.all.each do |premis_event_type|
+        expect(premis_event_type).to be_a Preservation::PremisEventType
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Moves method for returning all available Preservation::PremisEventType
  instances from `Preservation::Event#premis_event_types` to
  `Preservation::PremisEventType.all`.

NOTE: What we're really after is a controlled vocab for PREMIS Event Type URIs,
user-friendly labels, and abbreviations. There may be better tools for this,
i.e. the questioning_authority gem.