### PR TITLE
Refactors PremisEventType model

### DIFF
--- a/app/models/preservation/event.rb
+++ b/app/models/preservation/event.rb
@@ -14,8 +14,22 @@ module Preservation
       @user_from_db ||= User.where(email: premis_agent)
     end
 
+    # @return [String] the label of the PREMIS event type that corresponds
+    #   with the URI from the first value of the #premis_event_type property.
+    def premis_event_type_label
+      premis_event_type_object.label
+    end
+
     def self.indexer
       EventIndexer
     end
+
+    private
+      # @return [Preservation::PremisEventType] first PremisEventType instance
+      #   found where Preservation::PremisEventType#uri matches first value
+      #   found in #premis_event_type property.
+      def premis_event_type_object
+        @premis_event_type_object ||= Preservation::PremisEventType.find_by_uri(premis_event_type.first.id)
+      end
   end
 end

--- a/app/models/preservation/premis_event_type.rb
+++ b/app/models/preservation/premis_event_type.rb
@@ -1,3 +1,11 @@
+# A basic PORO model for PREMIS event types.
+#
+# The data for this model is not persisted to any data store. It is just
+# hardcoded (see Preservation::PremisEventyType.all).
+#
+# While only the URI of a PREMIS event type is stored on the
+# Preservation::Event#premis_event_type property, this PORO is used to pair
+# the URI with an abbreviation and a label.
 module Preservation
   class PremisEventType
     attr_reader :abbr, :label
@@ -11,7 +19,7 @@ module Preservation
       ::RDF::Vocab::PremisEventType.send(abbr)
     end
 
-    # Returns an array of instances of all known PREMIS event types
+    # @return [Array] list of all available PremisEventType instances.
     def self.all
       @all ||= [
         new('cap', 'PREMIS Capture'),
@@ -31,5 +39,18 @@ module Preservation
         new('vir', 'PREMIS Virus Check')
       ]
     end
+
+    # @param [String] URI to use for comparison. Note #to_s is called on the
+    #   param before comparing.
+    # @return [Preservation::PremisEventType] first found instance with URI
+    #   that matches parameter.
+    def self.find_by_uri(uri)
+      result = all.find { |record| record.uri.to_s == uri.to_s }
+      raise NotFound.new("PremisEventType with URI \"#{uri.to_s}\" was not found") unless result
+      result
+    end
+
+    # Custom Error Classes
+    class NotFound < StandardError; end
   end
 end

--- a/spec/models/preservation/event_spec.rb
+++ b/spec/models/preservation/event_spec.rb
@@ -6,9 +6,10 @@ describe Preservation::Event do
   end
 
   describe '#premis_event_type_label' do
-    let(:premis_event_type) { Preservation::Event.premis_event_types.sample }
+    let(:premis_event_type) { Preservation::PremisEventType.all.sample }
+    let(:event) { FactoryGirl.create(:event, premis_event_type: [premis_event_type.uri]) }
     it 'returns the label of the premis event type' do
-
+      expect(event.premis_event_type_label).to eq premis_event_type.label
     end
   end
 end

--- a/spec/models/preservation/premis_event_type_spec.rb
+++ b/spec/models/preservation/premis_event_type_spec.rb
@@ -21,4 +21,20 @@ describe Preservation::PremisEventType do
       end
     end
   end
+
+  describe '.find_by_uri' do
+    context 'when there is a corresponding instance that matches the URI passed in' do
+      let(:lookup_uri) { 'http://id.loc.gov/vocabulary/preservation/eventType/mes' }
+      it 'returns the instance' do
+        expect(Preservation::PremisEventType.find_by_uri(lookup_uri).uri.to_s).to eq lookup_uri
+      end
+    end
+
+    context 'when there is no corresponding record for the URI' do
+      let(:lookup_uri) { 'invalid-premis-event-type-uri' }
+      it 'raises a Preservation::PremisEventType::NotFound error' do
+        expect { Preservation::PremisEventType.find_by_uri(lookup_uri) }.to raise_error Preservation::PremisEventType::NotFound
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Adds class methods .all and .find_by_uri to Preservation::PremisEventType.
* Removes class method on Preservation::Event for returning
  Preservation::PremisEventType instances.
* Adds instance method Preservation::Event#premis_event_type_label.