### PR TITLE
Refactors PremisEventType model

### DIFF
--- a/app/models/preservation/premis_event_type.rb
+++ b/app/models/preservation/premis_event_type.rb
@@ -50,6 +50,12 @@ module Preservation
       result
     end
 
+    def self.find_by_abbr(abbr)
+      result = all.find { |record| record.abbr == abbr }
+      raise NotFound.new("PremisEventType with abbreviation \"#{abbr}\" was not found") unless result
+      result
+    end
+
     # Custom Error Classes
     class NotFound < StandardError; end
   end

--- a/spec/models/preservation/premis_event_type_spec.rb
+++ b/spec/models/preservation/premis_event_type_spec.rb
@@ -37,4 +37,20 @@ describe Preservation::PremisEventType do
       end
     end
   end
+
+  describe '.find_by_uri' do
+    context 'when there is a corresponding instance that matches the abbreviation passed in' do
+      let(:lookup_abbr) { 'cap' }
+      it 'returns the instance' do
+        expect(Preservation::PremisEventType.find_by_abbr(lookup_abbr).abbr).to eq lookup_abbr
+      end
+    end
+
+    context 'when there is no corresponding record for the abbreviation' do
+      let(:lookup_abbr) { 'blerg' }
+      it 'raises a Preservation::PremisEventType::NotFound error' do
+        expect { Preservation::PremisEventType.find_by_abbr(lookup_abbr) }.to raise_error Preservation::PremisEventType::NotFound
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Adds class methods .all, .find_by_uri, and .find_by_abbr to
  Preservation::PremisEventType.
* Removes class method on Preservation::Event for returning
  Preservation::PremisEventType instances.
* Adds instance method Preservation::Event#premis_event_type_label.